### PR TITLE
Support AJAX login and logout

### DIFF
--- a/Component/Authentication/Handler/LoginFailureHandler.php
+++ b/Component/Authentication/Handler/LoginFailureHandler.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  *
@@ -85,9 +86,15 @@ class LoginFailureHandler implements AuthenticationFailureHandlerInterface
             $session->set(SecurityContext::AUTHENTICATION_ERROR, $exception);
         }
 
-        return new RedirectResponse($this->container->get('router')->generate(
-			$this->container->getParameter('ccdn_user_security.login_shield.primary_login_route.name'),
-			$this->container->getParameter('ccdn_user_security.login_shield.primary_login_route.params')));
+        if ($request->isXmlHttpRequest() || $request->request->get('_format') === 'json') {
+            $response = new Response(json_encode(array('status' => 'failed', 'errors' => array($exception->getMessage()))));
+            $response->headers->set('Content-Type', 'application/json');
+            return $response;
+        } else {
+            return new RedirectResponse($this->container->get('router')->generate(
+                $this->container->getParameter('ccdn_user_security.login_shield.primary_login_route.name'),
+                $this->container->getParameter('ccdn_user_security.login_shield.primary_login_route.params')));
+        }
     }
 
 }

--- a/Component/Authentication/Handler/LoginSuccessHandler.php
+++ b/Component/Authentication/Handler/LoginSuccessHandler.php
@@ -17,6 +17,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerI
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  *
@@ -56,6 +57,11 @@ class LoginSuccessHandler implements AuthenticationSuccessHandlerInterface
         } else {
             // if no referer then go to homepage
             $response = new RedirectResponse($request->getBasePath() . '/');
+        }
+
+        if ($request->isXmlHttpRequest() || $request->request->get('_format') === 'json') {
+            $response = new Response(json_encode(array('status' => 'success')));
+            $response->headers->set('Content-Type', 'application/json');
         }
 
         return $response;

--- a/Component/Authentication/Handler/LogoutSuccessHandler.php
+++ b/Component/Authentication/Handler/LogoutSuccessHandler.php
@@ -14,8 +14,9 @@
 namespace CCDNUser\SecurityBundle\Component\Authentication\Handler;
 
 use Symfony\Component\Security\Http\Logout\LogoutSuccessHandlerInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  *
@@ -54,6 +55,11 @@ class LogoutSuccessHandler implements LogoutSuccessHandlerInterface
         } else {
             // if no referer then go to homepage
             $response = new RedirectResponse($request->getBasePath() . '/');
+        }
+
+        if ($request->isXmlHttpRequest() || $request->request->get('_format') === 'json') {
+            $response = new Response(json_encode(array('status' => 'success')));
+            $response->headers->set('Content-Type', 'application/json');
         }
 
         return $response;


### PR DESCRIPTION
Currently, if we want to support AJAX login and logout, we can only modify the return result by authentication handler. Each firewall section can only have one success_handler and failure_handler, and so the logic has to be resided here.
