### PR TITLE
use lowercase tablename

### DIFF
--- a/Resources/config/doctrine/Session.orm.yml
+++ b/Resources/config/doctrine/Session.orm.yml
@@ -1,6 +1,6 @@
 CCDNUser\SecurityBundle\Entity\Session:
     type: entity
-    table: CC_Security_Session
+    table: cc_security_session
     repositoryClass: CCDNUser\SecurityBundle\Repository\SessionRepository
     id:
         id:


### PR DESCRIPTION
Uppercase tablenames make problems in win/linux-world 

Could you change that, please? 
