### PR TITLE
Update DoctrineBundle API call from getEntityManager() to getManager()

### DIFF
--- a/Gateway/BaseGateway.php
+++ b/Gateway/BaseGateway.php
@@ -57,7 +57,7 @@ abstract class BaseGateway implements BaseGatewayInterface
 	{
 		$this->doctrine = $doctrine;
 		
-		$this->em = $doctrine->getEntityManager();
+		$this->em = $doctrine->getManager();
 		
 		$this->entityClass = $entityClass;
 	}

--- a/Manager/BaseManager.php
+++ b/Manager/BaseManager.php
@@ -60,7 +60,7 @@ abstract class BaseManager implements BaseManagerInterface
     {
         $this->doctrine = $doctrine;
 
-        $this->em = $doctrine->getEntityManager();
+        $this->em = $doctrine->getManager();
 		
 		$this->gateway = $gateway;
     }


### PR DESCRIPTION
According to https://github.com/doctrine/DoctrineBundle/blob/master/Registry.php#L71, we shall no longer call `getEntityManager()` but instead use `getManager()`.
