### PR TITLE
Added mising check for existence of master request

### DIFF
--- a/Component/Authorisation/SecurityManager.php
+++ b/Component/Authorisation/SecurityManager.php
@@ -96,8 +96,8 @@ class SecurityManager
      */
     public function vote()
     {
-        if ($this->forceAccountRecovery['enabled'] || $this->blockPages['enabled']) {
-            $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMasterRequest();
+        if (($this->forceAccountRecovery['enabled'] || $this->blockPages['enabled']) && $request) {
             $route = $request->get('_route');
             $ipAddress = $request->getClientIp();
 


### PR DESCRIPTION
Since <code>RequestStack::getMasterRequest()</code> also can return null, we need to make sure that <code>$request</code> is not null before performing any actions on it.
