### PR TITLE
Error from Scrutinizer

### DIFF
--- a/Tests/TestBase.php
+++ b/Tests/TestBase.php
@@ -57,7 +57,9 @@ class TestBase extends WebTestCase
      * message when running many tests
      */
 	public function tearDown(){
-		$this->container->get('doctrine')->getConnection()->close();
+		if($this->container !== null){
+			$this->container->get('doctrine')->getConnection()->close();
+		}
 	
 		parent::tearDown();
 	}


### PR DESCRIPTION
Trying to fix Error from Scrutinizer:
PHP Fatal error:  Call to a member function get() on a non-object in /home/scrutinizer/build/package/Tests/TestBase.php on line 60  
https://scrutinizer-ci.com/g/codeconsortium/CCDNUserSecurityBundle/inspections/d4678526-3c3f-4ba8-9de4-a01b168bbdfc

On my local environment the error does not happen, but at Scrutinizer, so I hope this solves the problem.
