### PR TITLE
Fixed script_phpunit.sh to make use of phpunit in vendor

### DIFF
--- a/script_phpunit.sh
+++ b/script_phpunit.sh
@@ -22,4 +22,4 @@ php ./Tests/Functional/app/console --env=test doctrine:database:create
 php ./Tests/Functional/app/console --env=test doctrine:schema:create
 php ./Tests/Functional/app/console --env=test doctrine:schema:update --force
 
-phpunit -c ./ --testdox
+./vendor/phpunit/phpunit/phpunit.php -c ./ --testdox


### PR DESCRIPTION
Title says all I guess, currently breaks when there is no globally installed phpunit
