### PR TITLE
Allow symfony/symfony 2.5 and 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "2.5.*",
+        "symfony/symfony": "~2.5,<2.7",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2"
     },


### PR DESCRIPTION
Symfony 2.5 won't receive bug fixes anymore starting from January 2015 and no more security fixes as of July 2015. CCDNUserSecurityBundle blocks our upgrade to 2.6 so we have two options:
- loosen the dependency constraint
- stop using CCDNUserSecurityBundle 

All tests pass for 2.6, so what's stopping us here? 

This fixes https://github.com/codeconsortium/CCDNUserSecurityBundle/issues/37
