### PR TITLE
Fixed: typo in LogoutSuccessHandler

### DIFF
--- a/Component/Authentication/Handler/LogoutSuccessHandler.php
+++ b/Component/Authentication/Handler/LogoutSuccessHandler.php
@@ -97,7 +97,7 @@ class LogoutSuccessHandler implements LogoutSuccessHandlerInterface
                     json_encode(
                         array(
                             'status' => 'failed',
-                            'errors' => array($exception->getMessage())
+                            'errors' => array()
                         )
                     )
                 );


### PR DESCRIPTION
Hi,

In `LogoutSuccessHandler` an undefined `$exception` is used.
Since it is a success handler, there is no exception, I guess it comes from a copy-paste from a failure hander.

Here is a fix of this typo. No BC no nothing.