### PR TITLE
Skipping XmlHttpRequests for setting Referer

### DIFF
--- a/Component/Listener/RouteRefererListener.php
+++ b/Component/Listener/RouteRefererListener.php
@@ -62,6 +62,12 @@ class RouteRefererListener
 
         // Get the route from the request object.
         $request = $event->getRequest();
+
+        // We skip AJAX requests
+        if ($request->isXmlHttpRequest()) {
+            return;
+        }
+
         $route = $request->get('_route');
 
         if (in_array($route, $this->routeIgnoreList)) {


### PR DESCRIPTION
Hi,

The `RouteReferer` listener catches all master request.
It feels like a safe setting to skip XmlHttp requests for setting refer, otherwise we may end up redirecting our user after logout to a random webservice.

Compatibility : no change
BC : may be, though that behavior was not really wanted from the start I guess.