### PR TITLE
remove upper version bound on symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/symfony": "~2.5,<2.7",
+        "symfony/symfony": "~2.5",
         "doctrine/orm": "~2.2,>=2.2.3",
         "doctrine/doctrine-bundle": "~1.2"
     },


### PR DESCRIPTION
We should be safe now to assume that 2.8 will not bring any BC breaking changes.

closes #46