### PR TITLE
More consistent HTTP code when flood

### DIFF
--- a/Component/Listener/AccessDeniedExceptionFactory.php
+++ b/Component/Listener/AccessDeniedExceptionFactory.php
@@ -19,6 +19,6 @@ class AccessDeniedExceptionFactory implements AccessDeniedExceptionFactoryInterf
 {
     public function createAccessDeniedException()
     {
-        return new HttpException(500, 'flood control - login blocked');
+        return new HttpException(429, 'flood control - login blocked');
     }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -138,6 +138,6 @@ class FeatureContext extends RawMinkContext implements KernelAwareInterface
      */
     public function iShouldBeBlocked()
     {
-        WebTestCase::assertSame(500, $this->getMainContext()->getSession()->getStatusCode());
+        WebTestCase::assertSame(429, $this->getMainContext()->getSession()->getStatusCode());
     }
 }


### PR DESCRIPTION
In accordance with RFC 6585
https://tools.ietf.org/html/rfc6585#section-4

(fresh new fork, following https://github.com/codeconsortium/CCDNUserSecurityBundle/pull/50)
